### PR TITLE
Explicit any for hideAutoCpmpleteDropdown param

### DIFF
--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -89,7 +89,7 @@ export class AutoCompleteDirective implements OnInit {
       setTimeout(this.styleAutoCompleteDropdown);
   }
 
-  hideAutoCompleteDropdown = (event?): void =>  {
+  hideAutoCompleteDropdown = (event?: any): void =>  {
     if (this.componentRef) {
       if (
         event && event.type === 'click' &&


### PR DESCRIPTION
Prevent this error for those with implicit any disabled:
node_modules/ng2-auto-complete/dist/auto-complete.directive.ts(92,31): error TS7006: Parameter 'event' implicitly has an 'any' type.

Or define a type for this.