### PR TITLE
Added check for null after matching provided source

### DIFF
--- a/src/ng2-auto-complete.ts
+++ b/src/ng2-auto-complete.ts
@@ -33,6 +33,10 @@ export class Ng2AutoComplete {
     }
 
     let matches = this.source.match(/:[a-zA-Z_]+/);
+    if (matches === null) {
+      throw "Replacement word is missing.";
+    }
+
     let replacementWord = matches[0];
     let url = this.source.replace(replacementWord, keyword);
 


### PR DESCRIPTION
If provided source has no replacement word declared like `:keyword`, so after matching ```matches``` become `null` and the error `Cannot read property '0' of null` will be thrown. I think it's not expected behavior, and it's doesn't help to understand a problem quickly, so for example I've created this PR as a one way to fix it. So if anyone has any questions or proposals, I am always ready to discuss. I can open issue or change branch for PR if needed.