### PR TITLE
fix ReadMe: FormControl had the wrong example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _ngModel_ http://plnkr.co/edit/3pB1Gx?p=preview
  _FormGroup_  http://plnkr.co/edit/2XRrck2cWVWcvbJnj6z5?p=preview
   [issue #49](https://github.com/ng2-ui/ng2-auto-complete/issues/49)
 
-_FormControl_ http://plnkr.co/edit/yCNNqBffko1VZFGpI2KU?p=preview 
+_FormControl_ http://plnkr.co/edit/WfgdcHLc8KDvsI2G2tHw?p=preview
   [issue #100](https://github.com/ng2-ui/ng2-auto-complete/issues/100)
 
 


### PR DESCRIPTION
For Some reason the plunkr i added was for `FormGroup` was linked to the same example for `FormControl`

Now it should be fixed.