### PR TITLE
Match keyword against list values formatted with list-formatter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ please send me email to `allenhwkim AT gmail.com` with your github id.
   * **`accept-user-input`** boolean, if `false` and does not match to source given, it goes back to the original value selected., If you don't event want user to type any, please use `readonly="readonly"` to force user to select only from list.
   * **`max-num-list`** number, maximun number of drop down list items. Default, unlimited
   * **`tab-to-select`** boolean, if `true`, pressing <kbd>Tab</kbd> will set the value from the selected item before focus leaves the control. Default is `true`
+  * **`match-formatted`** boolean, if `true`, keyword will be matched against list values formatted with `list-formatter`, instead of raw objects. Default is `false`
   
 ## For Developers
 

--- a/app/directive-test.component.ts
+++ b/app/directive-test.component.ts
@@ -45,7 +45,8 @@ let templateStr: string = `
         [(ngModel)]="model3"
         placeholder="enter text"
         value-formatter="(key) name"
-        list-formatter="(key) name" />
+        list-formatter="(key) name"
+        [match-formatted]="true" />
       <br/>selected model3: {{model3 | json}}<br/><br/>
     </ng2-utils-3>
     <pre>{{templateStr | htmlCode:'ng2-utils-3'}}</pre>
@@ -130,7 +131,7 @@ export class DirectiveTestComponent {
     [{id:1, value:"One"}, {id:2, value:"Two"}, {id:3, value:"Three"}, {id:4, value:"Four"}];
 
   arrayOfKeyValues2: any[] =
-    [{key:1, name:"Key One"}, {key:2, name:"Key Two"}, {key:3, name:"Key Three"}, {key:4, name:"Key Four"}];
+    [{id:11, key:1, name:"Key One"}, {id:12, key:2, name:"Key Two"}, {id:13, key:3, name:"Key Three"}, {id:14, key:4, name:"Key Four"}];
 
   googleGeoCode: string = "https://maps.googleapis.com/maps/api/geocode/json?address=:my_own_keyword";
 

--- a/src/ng2-auto-complete.component.ts
+++ b/src/ng2-auto-complete.component.ts
@@ -44,7 +44,7 @@ import { Ng2AutoComplete } from "./ng2-auto-complete";
           *ngFor="let item of filteredList; let i=index"
           (mousedown)="selectOne(item)"
           [ngClass]="{selected: i === itemIndex}"
-          [innerHtml]="getFormattedList(item)">
+          [innerHtml]="autoComplete.getFormattedListItem(item)">
       </li>
     </ul>
 
@@ -122,6 +122,7 @@ export class Ng2AutoCompleteComponent implements OnInit {
   @Input("show-input-tag") showInputTag: boolean = true;
   @Input("show-dropdown-on-init") showDropdownOnInit: boolean = false;
   @Input("tab-to-select") tabToSelect: boolean = true;
+  @Input("match-formatted") matchFormatted: boolean = false;
 
   @Output() valueSelected = new EventEmitter();
   @ViewChild('autoCompleteInput') autoCompleteInput: ElementRef;
@@ -156,6 +157,7 @@ export class Ng2AutoCompleteComponent implements OnInit {
   ngOnInit(): void {
     this.autoComplete.source = this.source;
     this.autoComplete.pathToData = this.pathToData;
+    this.autoComplete.listFormatter = this.listFormatter;
     setTimeout(() => {
       if (this.autoCompleteInput) {
         this.autoCompleteInput.nativeElement.focus()
@@ -201,7 +203,7 @@ export class Ng2AutoCompleteComponent implements OnInit {
 
     if (this.isSrcArr()) {    // local source
       this.isLoading = false;
-      this.filteredList = this.autoComplete.filter(this.source, keyword);
+      this.filteredList = this.autoComplete.filter(this.source, keyword, this.matchFormatted);
       if (this.maxNumList) {
         this.filteredList = this.filteredList.slice(0, this.maxNumList);
       }
@@ -277,25 +279,6 @@ export class Ng2AutoCompleteComponent implements OnInit {
         break;
     }
   };
-
-  getFormattedList(data: any): string {
-    let formatted;
-    let formatter = this.listFormatter || '(id) value';
-    if (typeof formatter === 'function') {
-      formatted = formatter.apply(this, [data]);
-    } else if (typeof data !== 'object') {
-      formatted = data;
-    } else if (typeof formatter === 'string') {
-      formatted = formatter;
-      let matches = formatter.match(/[a-zA-Z0-9_\$]+/g);
-      if (matches && typeof data !== 'string') {
-        matches.forEach(key => {
-          formatted = formatted.replace(key, data[key]);
-        });
-      }
-    }
-    return formatted;
-  }
 
   get emptyList(): boolean {
     return !(

--- a/src/ng2-auto-complete.directive.ts
+++ b/src/ng2-auto-complete.directive.ts
@@ -39,6 +39,7 @@ export class Ng2AutoCompleteDirective implements OnInit {
   @Input("no-match-found-text") noMatchFoundText: string;
   @Input("value-formatter") valueFormatter: any;
   @Input("tab-to-select") tabToSelect: boolean = true;
+  @Input("match-formatted") matchFormatted: boolean = false;
 
   @Input() ngModel: String;
   @Input('formControlName') formControlName: string;
@@ -141,6 +142,7 @@ export class Ng2AutoCompleteDirective implements OnInit {
     component.blankOptionText = this.blankOptionText;
     component.noMatchFoundText = this.noMatchFoundText;
     component.tabToSelect = this.tabToSelect;
+    component.matchFormatted = this.matchFormatted;
 
     component.valueSelected.subscribe(this.selectNewValue);
 

--- a/src/ng2-auto-complete.ts
+++ b/src/ng2-auto-complete.ts
@@ -11,20 +11,40 @@ export class Ng2AutoComplete {
 
   public source: string;
   public pathToData: string;
+  public listFormatter: (arg: any) => string;
 
   constructor(@Optional() private http: Http) {
     // ...
   }
 
-  filter(list: any[], keyword: string) {
+  filter(list: any[], keyword: string, matchFormatted: boolean) {
     return list.filter(
       el => {
-        let objStr = JSON.stringify(el).toLowerCase();
+        let objStr = matchFormatted ? this.getFormattedListItem(el).toLowerCase() : JSON.stringify(el).toLowerCase();
         keyword = keyword.toLowerCase();
         //console.log(objStr, keyword, objStr.indexOf(keyword) !== -1);
         return objStr.indexOf(keyword) !== -1;
       }
     );
+  }
+
+  getFormattedListItem(data: any) {
+    let formatted;
+    let formatter = this.listFormatter || '(id) value';
+    if (typeof formatter === 'function') {
+      formatted = formatter.apply(this, [data]);
+    } else if (typeof data !== 'object') {
+      formatted = data;
+    } else if (typeof formatter === 'string') {
+      formatted = formatter;
+      let matches = formatter.match(/[a-zA-Z0-9_\$]+/g);
+      if (matches && typeof data !== 'string') {
+        matches.forEach(key => {
+          formatted = formatted.replace(key, data[key]);
+        });
+      }
+    }
+    return formatted;
   }
 
   /**


### PR DESCRIPTION
Add new attribute [match-formatted]. When set to true, filtering of local source matches the keyword against list values formatted with list-formatter, instead of raw objects.